### PR TITLE
Avoid allocations on creation & recycle nodes to avoid allocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "linked-hash-map"
-version = "0.0.5"
+version = "0.0.6"
 license = "MIT/Apache-2.0"
 description = "A HashMap wrapper that holds key-value pairs in insertion order"
 authors = [


### PR DESCRIPTION
The first commit is obvious.

As for the second, it shaves a good 25% in a remove-insert cycle (as seen in the included benchmark). The memory usage patterns are consistent with a plain HashMap and it's possible to clear the free list by calling shrink_to_fit.

```
test tests::not_recycled_cycling ... bench:     218,208 ns/iter (+/- 14,423)
test tests::recycled_cycling     ... bench:     160,986 ns/iter (+/- 9,258)
```