### PR TITLE
Provide ::entry(K) API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -919,7 +919,7 @@ impl<'a, K: Hash + Eq, V, S: HashState> IntoIterator for &'a mut LinkedHashMap<K
 }
 
 /// A view into a single location in a map, which may be vacant or occupied.
-pub enum Entry<'a, K: 'a, V: 'a, S: 'a + HashState> {
+pub enum Entry<'a, K: 'a, V: 'a, S: 'a = hash_map::RandomState> {
     /// An occupied Entry.
     Occupied(OccupiedEntry<'a, K, V, S>),
     /// A vacant Entry.
@@ -927,14 +927,14 @@ pub enum Entry<'a, K: 'a, V: 'a, S: 'a + HashState> {
 }
 
 /// A view into a single occupied location in a LinkedHashMap.
-pub struct OccupiedEntry<'a, K: 'a, V: 'a, S: 'a + HashState> {
+pub struct OccupiedEntry<'a, K: 'a, V: 'a, S: 'a = hash_map::RandomState> {
     entry: *mut LinkedHashMapEntry<K, V>,
     map: *mut LinkedHashMap<K, V, S>,
     marker: marker::PhantomData<&'a K>,
 }
 
 /// A view into a single empty location in a HashMap.
-pub struct VacantEntry<'a, K: 'a, V: 'a, S: 'a + HashState> {
+pub struct VacantEntry<'a, K: 'a, V: 'a, S: 'a = hash_map::RandomState> {
     key: K,
     map: &'a mut LinkedHashMap<K, V, S>,
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 extern crate linked_hash_map;
 
-use linked_hash_map::LinkedHashMap;
+use linked_hash_map::{LinkedHashMap, Entry};
 
 fn assert_opt_eq<V: PartialEq>(opt: Option<&V>, v: V) {
     assert!(opt.is_some());
@@ -34,6 +34,37 @@ fn test_insert_update() {
     map.insert("1".to_string(), vec![10, 19]);
     assert_opt_eq(map.get(&"1".to_string()), vec![10, 19]);
     assert_eq!(map.len(), 1);
+}
+
+#[test]
+fn test_entry_insert_vacant() {
+    let mut map = LinkedHashMap::new();
+    match map.entry("1".to_string()) {
+        Entry::Vacant(e) => {
+            assert_eq!(*e.insert(vec![10, 10]), vec![10, 10]);
+        }
+        _ => panic!("fail"),
+    }
+    assert!(map.contains_key("1"));
+    assert_eq!(map["1"], vec![10, 10]);
+
+    match map.entry("1".to_string()) {
+        Entry::Occupied(mut e) => {
+            assert_eq!(*e.get(), vec![10, 10]);
+            assert_eq!(e.insert(vec![10, 16]), vec![10, 10]);
+        }
+        _ => panic!("fail"),
+    }
+
+    assert!(map.contains_key("1"));
+    assert_eq!(map["1"], vec![10, 16]);
+
+    match map.entry("1".to_string()) {
+        Entry::Occupied(e) => {
+            assert_eq!(e.remove(), vec![10, 16]);
+        }
+        _ => panic!("fail"),
+    }
 }
 
 #[test]


### PR DESCRIPTION
Mirror the equivalent HashMap API. Unfortunately, this implementation is not
able to provide the same benefits (reducing hashing) but provides utility in
having API parity as well as simplifies in-place entry manipulation.

Closes #5