### PR TITLE
Provide an iterator over OccupiedEntry

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -919,7 +919,7 @@ impl<'a, K: Hash + Eq, V, S: HashState> IntoIterator for &'a mut LinkedHashMap<K
 }
 
 /// A view into a single location in a map, which may be vacant or occupied.
-pub enum Entry<'a, K: 'a, V: 'a, S: 'a + HashState> {
+pub enum Entry<'a, K: 'a, V: 'a, S: 'a = hash_map::RandomState> {
     /// An occupied Entry.
     Occupied(OccupiedEntry<'a, K, V, S>),
     /// A vacant Entry.
@@ -927,14 +927,14 @@ pub enum Entry<'a, K: 'a, V: 'a, S: 'a + HashState> {
 }
 
 /// A view into a single occupied location in a LinkedHashMap.
-pub struct OccupiedEntry<'a, K: 'a, V: 'a, S: 'a + HashState> {
+pub struct OccupiedEntry<'a, K: 'a, V: 'a, S: 'a = hash_map::RandomState> {
     entry: *mut LinkedHashMapEntry<K, V>,
     map: *mut LinkedHashMap<K, V, S>,
     marker: marker::PhantomData<&'a K>,
 }
 
 /// A view into a single empty location in a HashMap.
-pub struct VacantEntry<'a, K: 'a, V: 'a, S: 'a + HashState> {
+pub struct VacantEntry<'a, K: 'a, V: 'a, S: 'a = hash_map::RandomState> {
     key: K,
     map: &'a mut LinkedHashMap<K, V, S>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -805,7 +805,7 @@ pub struct IterMut<'a, K: 'a, V: 'a> {
 
 /// An insertion-order iterator over a `LinkedHashMap`'s entries represented as
 /// an `OccupiedEntry`.
-pub struct Entries<'a, K: 'a, V: 'a, S: 'a> {
+pub struct Entries<'a, K: 'a, V: 'a, S: 'a = hash_map::RandomState> {
     map: *mut LinkedHashMap<K, V, S>,
     head: *mut LinkedHashMapEntry<K, V>,
     tail: *mut LinkedHashMapEntry<K, V>,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,6 @@
 extern crate linked_hash_map;
 
-use linked_hash_map::LinkedHashMap;
+use linked_hash_map::{LinkedHashMap, Entry};
 
 fn assert_opt_eq<V: PartialEq>(opt: Option<&V>, v: V) {
     assert!(opt.is_some());
@@ -34,6 +34,37 @@ fn test_insert_update() {
     map.insert("1".to_string(), vec![10, 19]);
     assert_opt_eq(map.get(&"1".to_string()), vec![10, 19]);
     assert_eq!(map.len(), 1);
+}
+
+#[test]
+fn test_entry_insert_vacant() {
+    let mut map = LinkedHashMap::new();
+    match map.entry("1".to_string()) {
+        Entry::Vacant(e) => {
+            assert_eq!(*e.insert(vec![10, 10]), vec![10, 10]);
+        }
+        _ => panic!("fail"),
+    }
+    assert!(map.contains_key("1"));
+    assert_eq!(map["1"], vec![10, 10]);
+
+    match map.entry("1".to_string()) {
+        Entry::Occupied(mut e) => {
+            assert_eq!(*e.get(), vec![10, 10]);
+            assert_eq!(e.insert(vec![10, 16]), vec![10, 10]);
+        }
+        _ => panic!("fail"),
+    }
+
+    assert!(map.contains_key("1"));
+    assert_eq!(map["1"], vec![10, 16]);
+
+    match map.entry("1".to_string()) {
+        Entry::Occupied(e) => {
+            assert_eq!(e.remove(), vec![10, 16]);
+        }
+        _ => panic!("fail"),
+    }
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -68,6 +68,21 @@ fn test_entry_insert_vacant() {
 }
 
 #[test]
+fn test_entries_replacing() {
+    let mut map = LinkedHashMap::new();
+    map.insert("a", 10);
+
+    {
+        let mut iter = map.entries();
+        let mut entry = iter.next().unwrap();
+        assert_eq!(entry.insert(20), 10);
+        assert!(iter.next().is_none());
+    }
+
+    assert_eq!(map["a"], 20);
+}
+
+#[test]
 fn test_debug() {
     let mut map = LinkedHashMap::new();
     assert_eq!(format!("{:?}", map), "{}");


### PR DESCRIPTION
Allows iterating `LinkedHashMap` entries with the option to remove visited entries during iteration.

Depends on #36