### PR TITLE
Discard gh-pages commit history

### DIFF
--- a/deploy-docs.sh
+++ b/deploy-docs.sh
@@ -10,11 +10,9 @@ git init
 git config user.email 'FlashCat@users.noreply.github.com'
 git config user.name 'FlashCat'
 git remote add upstream "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git"
-git fetch upstream gh-pages
-git reset upstream/gh-pages
 
 touch .
 
 git add -A .
-git commit -m "rebuild pages at ${rev}"
-git push -q upstream HEAD:gh-pages
+git commit -qm "rebuild pages at ${rev}"
+git push -q upstream HEAD:gh-pages --force


### PR DESCRIPTION
No reason to keep the commit history for gh-pages. The docs can be rebuilt at any commit at any time.

Keeping the history means `git log --graph --all` is cluttered with gh-pages commits. Even worse, they appear above the important commits because every commit to master is followed a few minutes later by a commit to gh-pages.