### PR TITLE
Publically expose LinkedHashMapVisitor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 
 // Optional Serde support
 #[cfg(feature = "serde_impl")]
-mod serde;
+pub mod serde;
 
 use std::borrow::Borrow;
 use std::cmp::Ordering;


### PR DESCRIPTION
This will be required for https://github.com/serde-rs/json/issues/54 because serde_json::Value will want to use the LinkedHashMapVisitor when visiting a map, similar to https://github.com/serde-rs/json/blob/7bc9b0a98ec65b90f8c4600d5966d1ca0679b089/json/src/value.rs#L391