### PR TITLE
Remove feature(hashmap_public_hasher)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@
 //! ```
 
 #![forbid(missing_docs)]
-#![cfg_attr(feature = "nightly", feature(hashmap_public_hasher))]
 #![cfg_attr(all(feature = "nightly", test), feature(test))]
 
 // Optional Serde support


### PR DESCRIPTION
This was stabilized in https://github.com/rust-lang/rust/pull/32804