### PR TITLE
Add `mark_lru` to change order of keys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -435,6 +435,8 @@ impl<K: Hash + Eq, V, S: BuildHasher> LinkedHashMap<K, V, S> {
     /// Returns `true` if the key is contained in the map and is now the least recently used entry,
     /// `false` otherwise.
     ///
+    /// # Examples
+    ///
     /// ```
     /// use linked_hash_map::LinkedHashMap;
     /// let mut map = LinkedHashMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
     }
 
     #[inline]
-    fn attach(&mut self, node: *mut Node<K, V>) {
+    fn attach_next(&mut self, node: *mut Node<K, V>) {
         unsafe {
             (*node).next = (*self.head).next;
             (*node).prev = self.head;
@@ -328,12 +328,12 @@ impl<K: Hash + Eq, V, S: BuildHasher> LinkedHashMap<K, V, S> {
             Some(_) => {
                 // Existing node, just update LRU position
                 self.detach(node);
-                self.attach(node);
+                self.attach_next(node);
             }
             None => {
                 let keyref = unsafe { &(*node).key };
                 self.map.insert(KeyRef{k: keyref}, node);
-                self.attach(node);
+                self.attach_next(node);
             }
         }
         old_val
@@ -410,7 +410,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> LinkedHashMap<K, V, S> {
         };
         if let Some(node_ptr) = node_ptr_opt {
             self.detach(node_ptr);
-            self.attach(node_ptr);
+            self.attach_next(node_ptr);
         }
         value
     }
@@ -1250,7 +1250,7 @@ impl<'a, K: Hash + Eq, V, S: BuildHasher> OccupiedEntry<'a, K, V, S> {
 
             // Existing node, just update LRU position
             (*self.map).detach(node_ptr);
-            (*self.map).attach(node_ptr);
+            (*self.map).attach_next(node_ptr);
 
             old_val
         }
@@ -1297,7 +1297,7 @@ impl<'a, K: 'a + Hash + Eq, V: 'a, S: BuildHasher> VacantEntry<'a, K, V, S> {
 
         let keyref = unsafe { &(*node).key };
 
-        self.map.attach(node);
+        self.map.attach_next(node);
 
         let ret = self.map.map.entry(KeyRef{k: keyref}).or_insert(node);
         unsafe { &mut (**ret).value }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -412,3 +412,31 @@ fn test_send_sync() {
     is_send_sync::<linked_hash_map::Keys<u32, i32>>();
     is_send_sync::<linked_hash_map::Values<u32, i32>>();
 }
+
+#[test]
+fn mark_lru() {
+    let mut map: LinkedHashMap<u32, u32> = LinkedHashMap::new();
+    map.insert(1, 1);
+    assert_eq!(map.front(), Some((&1, &1)));
+
+    map.insert(2, 2);
+    assert_eq!(map.front(), Some((&1, &1)));
+
+    assert!(map.mark_lru(&2));
+    assert_eq!(map.front(), Some((&2, &2)));
+
+    map.pop_front();
+    assert_eq!(map.front(), Some((&1, &1)));
+
+    assert!(map.mark_lru(&1));
+    assert_eq!(map.pop_front(), Some((1, 1)));
+}
+
+#[test]
+fn mark_lru_non_existent() {
+    let mut map: LinkedHashMap<u32, u32> = LinkedHashMap::new();
+    assert!(!map.mark_lru(&1));
+    map.insert(1, 1);
+
+    assert!(!map.mark_lru(&2));
+}


### PR DESCRIPTION
Hi there,

When using `linked-hash-map` as a cache I'd like to mark possibly no-longer needed nodes as least recently used so that they will be the first to go. I will be making a simpler PR to `lru-cache` if this gets accepted.

Two commits, first renames the existing `fn attach(..)` to `fn attach_next(..)` which I think is suitable as the second commit adds an `fn attach_prev(..)` which will be invoked by **`mark_lru(..)`** together with `fn detach(..)`.

Naming: the current API has `pop_front` and `front` for the last element in the list and *`lru`* is not exactly a term for linked-hash-map. I'm not sure which would be more suitable name, `move_front`, `set_front`, `assign_front` or perhaps `mark_front`?