### PR TITLE
fix safety issue in entries() iterator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,6 @@ impl<K: Hash + Eq, V, S: BuildHasher> LinkedHashMap<K, V, S> {
         Entries {
             map: self,
             head: head,
-            tail: self.head,
             remaining: self.len(),
             marker: marker::PhantomData,
         }
@@ -844,7 +843,6 @@ pub struct IntoIter<K, V> {
 pub struct Entries<'a, K: 'a, V: 'a, S: 'a = hash_map::RandomState> {
     map: *mut LinkedHashMap<K, V, S>,
     head: *mut Node<K, V>,
-    tail: *mut Node<K, V>,
     remaining: usize,
     marker: marker::PhantomData<(&'a K, &'a mut V, &'a S)>,
 }
@@ -971,7 +969,7 @@ impl<'a, K, V, S: BuildHasher> Iterator for Entries<'a, K, V, S> {
     type Item = OccupiedEntry<'a, K, V, S>;
 
     fn next(&mut self) -> Option<OccupiedEntry<'a, K, V, S>> {
-        if self.head == self.tail {
+        if self.remaining == 0 {
             None
         } else {
             self.remaining -= 1;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -140,6 +140,18 @@ fn test_entries_remove() {
 
     assert!(map.is_empty());
 }
+#[test]
+fn entries_insert() {
+    let mut map = LinkedHashMap::new();
+    map.insert(0, 0);
+    map.insert(1, 1);
+
+    let mut iter = map.entries();
+
+    iter.next().unwrap().insert(0);
+    iter.next().unwrap(); // 1
+    assert!(iter.next().is_none());
+}
 
 #[test]
 fn test_debug() {


### PR DESCRIPTION
This fixes an issue where the entries() iterator could be used to get two mutable references that alias each other, as demonstrated in this piece of code:

    let mut map = LinkedHashMap::new();
    map.insert(0, 0);
    map.insert(1, 1);

    let mut iter = map.entries();

    let mut zero = iter.next().unwrap();
    zero.insert(0); // moves the zero entry to the end
    iter.next().unwrap(); // 1

    let mut zero_alias = iter.next(); // in release mode, this silently underflows iter.remaining
    assert_eq!(zero.get_mut() as *mut i32, zero_alias.unwrap().get_mut() as *mut i32);