### PR TITLE
Fix validity problem

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,8 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         if self.head.is_null() {
             // allocate the guard node if not present
             unsafe {
-                self.head = Box::into_raw(Box::new(mem::uninitialized()));
+                let node_layout = std::alloc::Layout::new::<Node<K, V>>();
+                self.head =  std::alloc::alloc(node_layout) as *mut Node<K, V>;
                 (*self.head).next = self.head;
                 (*self.head).prev = self.head;
             }


### PR DESCRIPTION
This PR addresses two problems.
- `mem::uninitialized` is going to be deprecated.
- When K or V type has niche (e.g. `bool` or `char`), creating Node with `mem::uninitialized()` has undefined behavior.