### PR TITLE
Fix mem::uninitialized UB warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1135,7 +1135,7 @@ impl<K: Hash + Eq, V, S: BuildHasher> IntoIterator for LinkedHashMap<K, V, S> {
         }
         self.clear_free_list();
         // drop the HashMap but not the LinkedHashMap
-        self.map = unsafe { mem::uninitialized() };
+        unsafe { ptr::drop_in_place(&mut self.map); }
         mem::forget(self);
 
         IntoIter {


### PR DESCRIPTION
Scary-looking warning fixable *as far as I can tell* with one-line patch
```
warning: use of deprecated item 'std::mem::uninitialized': use `mem::MaybeUninit` instead
    --> src/lib.rs:1138:29
     |
1138 |         self.map = unsafe { mem::uninitialized() };
     |                             ^^^^^^^^^^^^^^^^^^
     |
     = note: `#[warn(deprecated)]` on by default

warning: the type `std::collections::HashMap<KeyRef<K>, *mut Node<K, V>, S>` does not permit being left uninitialized
    --> src/lib.rs:1138:29
     |
1138 |         self.map = unsafe { mem::uninitialized() };
     |                             ^^^^^^^^^^^^^^^^^^^^
     |                             |
     |                             this code causes undefined behavior when executed
     |                             help: use `MaybeUninit<T>` instead
     |
     = note: `#[warn(invalid_value)]` on by default
note: std::ptr::NonNull<u8> must be non-null (in this struct field)
```