### PR TITLE
add repr(transparent) to Qey

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@ impl<K: Eq> Eq for KeyRef<K> {}
 // due to conflicting implementations of `Borrow`. The layout of `&Qey<Q>` must be identical to
 // `&Q` in order to support transmuting in the `Qey::from_ref` method.
 #[derive(Hash, PartialEq, Eq)]
+#[repr(transparent)]
 struct Qey<Q: ?Sized>(Q);
 
 impl<Q: ?Sized> Qey<Q> {


### PR DESCRIPTION
`#[repr(transparent)]` guarantees that `Qey<Q>` has the same memory layout
as `Q` (https://doc.rust-lang.org/nomicon/other-reprs.html#reprtransparent).
This is required for `Qey::from_ref` to be safe.