### PR TITLE
Update doc link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 
 repository = "https://github.com/contain-rs/linked-hash-map"
 homepage = "https://github.com/contain-rs/linked-hash-map"
-documentation = "https://contain-rs.github.io/linked-hash-map/linked_hash_map"
+documentation = "https://docs.rs/linked-hash-map"
 keywords = ["data-structures"]
 readme = "README.md"
 exclude = ["/.travis.yml", "/deploy-docs.sh"]

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ We are currently only accepting changes which:
 
 A HashMap wrapper that holds key-value pairs in insertion order.
 
-Documentation is available at https://contain-rs.github.io/linked-hash-map/linked_hash_map.
+Documentation is available at https://docs.rs/linked-hash-map.


### PR DESCRIPTION
https://contain-rs.github.io/linked-hash-map/linked_hash_map no longer works. This PR updates the link to use the docs.rs page instead.

Fixes #103.