### PR TITLE
Implement `.or_default()` for Entry

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1211,6 +1211,14 @@ impl<'a, K: Hash + Eq, V, S: BuildHasher> Entry<'a, K, V, S> {
     }
 }
 
+impl<'a, K: Hash + Eq, V: Default, S: BuildHasher> Entry<'a, K, V, S> {
+    /// Ensures a value is in the entry by inserting the Default::default() if empty, and returns
+    /// a mutable reference to the value in the entry.
+    pub fn or_default(self) -> &'a mut V {
+        self.or_insert(Default::default())
+    }
+}
+
 impl<'a, K: Hash + Eq, V, S: BuildHasher> OccupiedEntry<'a, K, V, S> {
     /// Gets a reference to the entry key
     ///


### PR DESCRIPTION
Hi, nothing special, just additional method to quickly insert default value into Entry, similar to what `std::collections::HashMap` does.